### PR TITLE
Replace calls to getpid() by syscall(SYS_gettid)

### DIFF
--- a/src/libveo/ProcHandle.cpp
+++ b/src/libveo/ProcHandle.cpp
@@ -53,7 +53,7 @@ int init_lhm_shm_area(veos_handle *handle)
   VEO_TRACE(ctx, "Entering %s", __func__);
 
   /* Allocate shared memory segment */
-  retval = shmget(getpid(), PAGE_SIZE_4KB, IPC_CREAT|S_IRWXU);
+  retval = shmget(syscall(SYS_gettid), PAGE_SIZE_4KB, IPC_CREAT|S_IRWXU);
   if (-1 == retval) {
     VEO_DEBUG(ctx, "Failed to get shared memory (errno=%d)", errno);
     goto out_error1;
@@ -190,7 +190,7 @@ int spawn_helper(ThreadContext *ctx, veos_handle *oshandle, const char *binname)
   global_tid_info[0].vefd = oshandle->ve_handle->vefd;
   global_tid_info[0].veos_hndl = oshandle;
   tid_counter = 0;
-  global_tid_info[0].tid_val = getpid();// main thread
+  global_tid_info[0].tid_val = syscall(SYS_gettid);// main thread
   global_tid_info[0].flag = 0;
   global_tid_info[0].mutex = PTHREAD_MUTEX_INITIALIZER;
   global_tid_info[0].cond = PTHREAD_COND_INITIALIZER;


### PR DESCRIPTION
This allows us to use veoffload from other threads than the main thread.
For this to work though, we need to do same for veos in pseudo_psm_send_start_ve_proc_req().

For example, without these changes, the following hello.cpp program fails with `Segmentation fault` because `proc` is `NULL`
```cpp
#include <ve_offload.h>
#include <thread>
int main()
{
    std::thread t([]() {
        struct veo_proc_handle *proc = veo_proc_create(0);/* on VE node #0 */
        uint64_t handle = veo_load_library(proc, "./libvehello.so");
        uint64_t sym = veo_get_sym(proc, handle, "hello");
        struct veo_thr_ctxt *ctx = veo_context_open(proc);
        struct veo_args *argp = veo_args_alloc();
        uint64_t id = veo_call_async(ctx, sym, argp);
        uint64_t retval;
        veo_call_wait_result(ctx, id, &retval);
        veo_args_free(argp);
        veo_context_close(ctx);
    });
    t.join();
    return 0;
}
```
However, with this patch, and the one for veos, and a `libhello.so` file obtained as per 
https://github.com/veos-sxarr-NEC/veoffload/blob/master/doc/GettingStarted.md ,
it executes successfully and outputs `Hello, world` as expected.

This is especially problematic for Java because JVMs typically do not run `main()` on the main thread:
> 5. Creates the VM using `JNI_CreateJavaVM` in a newly created thread (non primordial thread). Note: creating the VM in the primordial thread greatly reduces the ability to customize the VM, for example the stack size on Windows, and many other limitations

https://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html